### PR TITLE
Redirect to login page when loading pages without logged user

### DIFF
--- a/src/components/AdvocateNotes.tsx
+++ b/src/components/AdvocateNotes.tsx
@@ -31,8 +31,8 @@ const Search: React.FC = () => (
 
 // eslint-disable-next-line react/prop-types
 const AdvocateNotes: AdminView = () => {
+  // TODO: put in shared custom hook
   const history = useHistory();
-
   const {
     routes: { admin: adminRoute },
   } = useConfig();

--- a/src/components/AdvocateNotes.tsx
+++ b/src/components/AdvocateNotes.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useHistory } from "react-router-dom";
 
 import { AdminView } from "payload/config";
-import { useConfig } from "payload/components/utilities";
+import { useConfig, useAuth } from "payload/components/utilities";
 import { DefaultTemplate } from "payload/components/templates";
 import { Button } from "payload/components";
 import { fetchNotes } from "../utils/REST";
@@ -30,18 +30,25 @@ const Search: React.FC = () => (
 );
 
 // eslint-disable-next-line react/prop-types
-const AdvocateNotes: AdminView = ({ user }) => {
-  const [notes, setNotes] = useState<Array<INotesSchema>>([]);
-  const [searchTerm, setSearchTerm] = useState("");
+const AdvocateNotes: AdminView = () => {
   const history = useHistory();
 
   const {
     routes: { admin: adminRoute },
   } = useConfig();
 
+  const { user } = useAuth();
+  if (!user) {
+    history.push({
+      pathname: `${adminRoute}`,
+    });
+  }
+
+  const [notes, setNotes] = useState<Array<INotesSchema>>([]);
+  const [searchTerm, setSearchTerm] = useState("");
+
   useEffect(() => {
     const getNotes = async () => {
-      // eslint-disable-next-line react/prop-types
       const totalNotes = await fetchNotes(user.email);
       totalNotes?.sort(
         (a, b) =>
@@ -50,9 +57,7 @@ const AdvocateNotes: AdminView = ({ user }) => {
       setNotes(totalNotes);
     };
 
-    if (typeof user !== "undefined") {
-      getNotes();
-    }
+    getNotes();
   }, [user]);
 
   const filteredNotes = notes?.filter((item) =>

--- a/src/components/AdvocateNotes.tsx
+++ b/src/components/AdvocateNotes.tsx
@@ -1,13 +1,11 @@
 import React, { useEffect, useState } from "react";
-import { useHistory } from "react-router-dom";
-
 import { AdminView } from "payload/config";
-import { useConfig, useAuth } from "payload/components/utilities";
 import { DefaultTemplate } from "payload/components/templates";
 import { Button } from "payload/components";
 import { fetchNotes } from "../utils/REST";
 import { INotesSchema } from "../schema/noteCollectionSchema";
 import { displayDateTime } from "../utils/utils";
+import useRedirectLogin from "./RedirectLogin";
 
 import "./Components.scss";
 
@@ -31,18 +29,7 @@ const Search: React.FC = () => (
 
 // eslint-disable-next-line react/prop-types
 const AdvocateNotes: AdminView = () => {
-  // TODO: put in shared custom hook
-  const history = useHistory();
-  const {
-    routes: { admin: adminRoute },
-  } = useConfig();
-
-  const { user } = useAuth();
-  if (!user) {
-    history.push({
-      pathname: `${adminRoute}`,
-    });
-  }
+  const { user, adminRoute, history } = useRedirectLogin();
 
   const [notes, setNotes] = useState<Array<INotesSchema>>([]);
   const [searchTerm, setSearchTerm] = useState("");

--- a/src/components/NoteEditor.tsx
+++ b/src/components/NoteEditor.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useHistory, useLocation } from "react-router-dom";
-
 import { Form, Submit, Text, Select } from "payload/components/forms";
 import { MinimalTemplate, Button } from "payload/components";
 import { AdminView } from "payload/config";
@@ -13,15 +12,21 @@ import "./Components.scss";
 
 const NoteEditor: AdminView = () => {
   const history = useHistory();
-  const location = useLocation();
-  const { user } = useAuth();
-
-  const noteToEdit = location?.state?.note as INotesSchema;
-  const isCreateNote = typeof noteToEdit === "undefined";
-
   const {
     routes: { admin: adminRoute },
   } = useConfig();
+
+  const { user } = useAuth();
+  if (!user) {
+    history.push({
+      pathname: `${adminRoute}`,
+    });
+  }
+
+  const location = useLocation();
+
+  const noteToEdit = location?.state?.note as INotesSchema;
+  const isCreateNote = typeof noteToEdit === "undefined";
 
   const onSubmit = async (fields: any) => {
     try {

--- a/src/components/NoteEditor.tsx
+++ b/src/components/NoteEditor.tsx
@@ -1,28 +1,17 @@
 import React from "react";
-import { useHistory, useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 import { Form, Submit, Text, Select } from "payload/components/forms";
 import { MinimalTemplate, Button } from "payload/components";
 import { AdminView } from "payload/config";
-import { useConfig, useAuth } from "payload/components/utilities";
 import { MIN_NOTE_CHARS, MAX_NOTE_CHARS, typeOptions } from "../constants";
 import { INotesSchema } from "../schema/noteCollectionSchema";
 import { deleteNote, createAndUpdateNote } from "../utils/REST";
+import useRedirectLogin from "./RedirectLogin";
 
 import "./Components.scss";
 
 const NoteEditor: AdminView = () => {
-  // TODO: put in shared custom hook
-  const history = useHistory();
-  const {
-    routes: { admin: adminRoute },
-  } = useConfig();
-
-  const { user } = useAuth();
-  if (!user) {
-    history.push({
-      pathname: `${adminRoute}`,
-    });
-  }
+  const { user, adminRoute, history } = useRedirectLogin();
 
   const location = useLocation();
 

--- a/src/components/NoteEditor.tsx
+++ b/src/components/NoteEditor.tsx
@@ -11,6 +11,7 @@ import { deleteNote, createAndUpdateNote } from "../utils/REST";
 import "./Components.scss";
 
 const NoteEditor: AdminView = () => {
+  // TODO: put in shared custom hook
   const history = useHistory();
   const {
     routes: { admin: adminRoute },

--- a/src/components/RedirectLogin.tsx
+++ b/src/components/RedirectLogin.tsx
@@ -1,0 +1,20 @@
+import { useHistory } from "react-router-dom";
+import { useConfig, useAuth } from "payload/components/utilities";
+
+const useRedirectLogin = () => {
+  const history = useHistory();
+  const {
+    routes: { admin: adminRoute },
+  } = useConfig();
+  const { user } = useAuth();
+
+  if (!user) {
+    history.push({
+      pathname: `${adminRoute}`,
+    });
+  }
+
+  return { user, adminRoute, history };
+};
+
+export default useRedirectLogin;

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -7,14 +7,6 @@ import AfterNavLinks from "./components/AfterNavLinks";
 import SolaceLanding from "./components/SolaceLanding";
 import NoteEditor from "./components/NoteEditor";
 
-const adminRoute: AdminRoute = {
-  Component: SolaceLanding,
-  path: "/home",
-  exact: true,
-  sensitive: false,
-  strict: false,
-};
-
 const advocateNotesRoute: AdminRoute = {
   Component: AdvocateNotes,
   path: "/advocate-notes",
@@ -53,7 +45,6 @@ export default buildConfig({
       },
       routes: [
         advocateNotesRoute,
-        adminRoute,
         {
           path: "/advocate-notes/note-editor",
           Component: NoteEditor,


### PR DESCRIPTION
1. Check at the top of each page to ensure that a logged-in user is present.
2. Removed path: "/home" as it does not exist any more
3. Added useRedirectLogin custom hook.

TODO: 
1. Replace Payload with Solace on logging page.
2. Some code cleaning.

Note: please see https://github.com/agolovan/solace-advocate-notes/compare/master...fix-routes for all changes
